### PR TITLE
JD2XXInputStream overrides InputStream.available()

### DIFF
--- a/jd2xx/jd2xx/JD2XXInputStream.java
+++ b/jd2xx/jd2xx/JD2XXInputStream.java
@@ -66,4 +66,9 @@ public class JD2XXInputStream extends InputStream {
 	public int read(byte[] b) throws IOException {
 		return jd2xx.read(b);
 	}
+
+	public int available() throws IOException {
+		return jd2xx.getQueueStatus();
+	}
+
 }


### PR DESCRIPTION
A call to jd2xx.getQueueStatus() is necessary to get the input buffer size. Otherwise, 0 is always obtained.
